### PR TITLE
履歴管理機能を実装

### DIFF
--- a/content.js
+++ b/content.js
@@ -238,8 +238,10 @@ const saveCaptions = () => {
       outputText += `\n${caption.speaker}:\n ${caption.text}\n`;
     });
 
+    const fileContent = headerText + outputText + '\n';
+
     // ファイル作成
-    const blob = new Blob([headerText + outputText + '\n'], { type: fileFormat });
+    const blob = new Blob([fileContent], { type: fileFormat });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
@@ -256,6 +258,20 @@ const saveCaptions = () => {
     caption = {};
     captions = [];
     outputText = '';
+
+    // 履歴保存（最大25件）
+    if (options?.saveHistory) {
+      chrome.storage.local.get('history', ({ history = [] }) => {
+        const entry = {
+          savedAt: new Date().toISOString(),
+          fileName,
+          fileFormat,
+          content: fileContent,
+        };
+        const updatedHistory = [entry, ...(history || [])].slice(0, 25);
+        chrome.storage.local.set({ history: updatedHistory });
+      });
+    }
   });
 };
 

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -5,7 +5,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Google Meet Captions Logger</title>
-  <!-- <link rel="stylesheet" href="popup.css"> -->
   <link rel="stylesheet" href="bootstrap-5.3.0-dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="popup.css">
 </head>
@@ -44,6 +43,10 @@
     <li class="nav-item " role="presentation">
       <a class="nav-link active py-1 p-md-2" id="settings-tab" data-bs-toggle="tab" href="#settings" role="tab"
         aria-controls="settings " aria-selected="true">設定</a>
+    </li>
+    <li class="nav-item" role="presentation">
+      <a class="nav-link py-1 p-md-2" id="history-tab" data-bs-toggle="tab" href="#history" role="tab"
+        aria-controls="history" aria-selected="false">履歴</a>
     </li>
     <li class="nav-item" role="presentation">
       <a class="nav-link py-1 p-md-2" id="document-tab" data-bs-toggle="tab" href="#document" role="tab"
@@ -124,9 +127,24 @@ meet開始時刻    : {meet開始時刻}
             <input class="form-check-input" type="checkbox" id="saveOnTabClose">
             <label class="form-check-label" for="saveOnTabClose">タブを閉じた時に保存する</label>
           </div>
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="saveHistory">
+            <label class="form-check-label" for="saveHistory">履歴を保存する（最大25件）</label>
+          </div>
         </div>
       </fieldset>
+    </div>
 
+    <!-- 履歴 -->
+    <div class="tab-pane fade mt-2 mx-2" id="history" role="tabpanel" style="margin-bottom: 200px;"
+      aria-labelledby="history-tab">
+      <div class="d-flex justify-content-between align-items-center pt-3 ps-2 mb-2">
+        <h5 class="m-0">保存履歴</h5>
+        <small class="text-muted">最大25件</small>
+      </div>
+      <ul class="list-group" id="historyList">
+        <li class="list-group-item text-muted" id="historyEmpty">履歴がまだありません</li>
+      </ul>
     </div>
 
     <!-- ドキュメント -->


### PR DESCRIPTION
- ポップアップに「履歴」タブを追加
- 最大25件の字幕保存履歴を管理
- ダウンロード機能（TXT/CSV/MD形式対応）
- オプション「履歴を保存する」を追加（デフォルトOFF）